### PR TITLE
fix #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "importPaths": ["src"],
     "targetType":  "library",
     "dependencies": { 
-        "msgpack-d": ">=0.9.2",
+        "msgpack-d": ">=1.0.0-beta.7",
         "vibe-d": ">=0.7.25"
     },
     "configurations": [


### PR DESCRIPTION
Fix #19 
[Implicit catch statement](https://dlang.org/deprecate.html#Implicit%20catch%20statement)

Due to this deprecated features, it is necessary to change the version of msgpack-d.